### PR TITLE
Add support for path prefix and global variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,30 +16,37 @@ const File = require('vinyl')
 //               resulting module exports an object with views keyed by short
 //               file paths. If not provided, each module exports its view as a
 //               string.
+//   .prefix  -- prepend a prefix (e.g. file path) to the filename for each of
+//               the HTML files supplied. Do not include the trailing slash, as
+//               it gets added automatically.
+//   .global  -- override the variable to which the list of HTML strings is
+//               assigned to. For example `window.templates`. If not provided,
+//               `module.exports` will be used for compatibility with node.js
 module.exports = options => (
   options && options.concat
-  ? concatMode(options.concat)
+  ? concatMode(options)
   : baseMode()
 )
 
-function concatMode (concat) {
-  if (typeof concat !== 'string') {
-    throw Error(`Option 'concat' must be a string, got: ${concat}`)
+function concatMode (options) {
+  if (typeof options.concat !== 'string') {
+    throw Error(`Option 'concat' must be a string, got: ${options.concat}`)
   }
 
+  options.global = options.global || 'module.exports'
   const results = []
 
   return through.obj(
     function transform (file, _, done) {
       if (file.isBuffer()) {
-        results.push(textToExport(file.contents.toString(), file.relative))
+        results.push(textToExport(file.contents.toString(), file.relative, options))
       }
       done(null)
     },
     function flush (done) {
       this.push(new File({
-        path: concat,
-        contents: new Buffer(join(results))
+        path: options.concat,
+        contents: new Buffer(join(results, options))
       }))
       done(null)
     }
@@ -63,13 +70,16 @@ module.exports = '${escape(text)}';
 `
 }
 
-function textToExport (text, path) {
-  return `module.exports['${escape(path)}'] = '${escape(text)}'`
+function textToExport (text, path, options) {
+  if (options.prefix) {
+    path = `${options.prefix}/${path}`
+  }
+  return `${options.global}['${escape(path)}'] = '${escape(text)}'`
 }
 
-function join (results) {
+function join (results, options) {
   return `'use strict';
-module.exports = Object.create(null);
+${options.global} = Object.create(null);
 ${results.join(';\n')};
 `
 }

--- a/readme.md
+++ b/readme.md
@@ -60,3 +60,30 @@ In your app, import the result like so:
 ```typescript
 import views from 'views';
 ```
+
+## Other options
+
+When using the `concat` option, there are other options that can be used to
+modify its behavior:
+
+* prefix: Prepends a path prefix to all keys of the resulting module object.
+
+For `{prefix: 'templates'}` the resulting file from the above example is:
+
+```javascript
+'use strict';
+module.exports = Object.create(null);
+module.exports['templates/index.html'] = '<p>Hello world!</p>';
+```
+
+* global: Assigns the resulting object to a global variable other than
+  `module.exports`. This allows for compatibility with other systems or for
+  client-side template caching.
+
+For `{global: 'window.templates'}` the resulting file from the above example is:
+
+```javascript
+'use strict';
+window.templates = Object.create(null);
+window.templates['index.html'] = '<p>Hello world!</p>';
+```


### PR DESCRIPTION
- Added support for prepending path prefixes to the resulting keys
- Added support for overriding `module.exports` so that it can be used with other systems (e.g. client-side template loading)
- Updated tests to account for new options
- Small change in tests to allow for testing in non-Unix environments
