### PR TITLE
On Windows used \ as directory separator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ function textToExport (text, path, options) {
   if (options.prefix) {
     path = `${options.prefix}/${path}`
   }
-  return `${options.global}['${escape(path)}'] = '${escape(text)}'`
+  return `${options.global}['${normalizePath(path)}'] = '${escape(text)}'`
 }
 
 function join (results, options) {
@@ -82,6 +82,13 @@ function join (results, options) {
 ${options.global} = Object.create(null);
 ${results.join(';\n')};
 `
+}
+
+/**
+ * Convert path to Linux style when running on Windows machine
+ */
+function normalizePath(text) {
+    return escape(text).replace(/\\/g, '/');
 }
 
 function escape (text) {


### PR DESCRIPTION
This was causing escaping on the next symbols when using 'concat' mode
